### PR TITLE
Add CLI goal manager with reminder workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# ss
-ss
+# 目标管理器
+
+这是一个简单的命令行目标管理器，可以在电脑上运行，用于记录每日、每周、每月和每年的目标完成情况。程序会把数据保存在同目录下的 `goal_manager.json` 中，因此多次运行都会保留历史。
+
+## 使用方法
+
+1. **添加目标**
+
+   ```bash
+   python goal_manager.py add "锻炼" --frequency daily
+   python goal_manager.py add "整理财务" --frequency monthly
+   ```
+
+2. **查看目标和今日状态**
+
+   ```bash
+   python goal_manager.py list
+   ```
+
+3. **每日提醒**：运行下面的命令，程序会询问每个目标今天（或当期）是否完成，按下 `y`/`n` 或直接回车跳过。
+
+   ```bash
+   python goal_manager.py remind
+   ```
+
+4. **手动修改状态**
+
+   ```bash
+   python goal_manager.py check "锻炼" --frequency daily --done
+   python goal_manager.py check "整理财务" --frequency monthly --not-done
+   ```
+
+建议把提醒命令加入系统的计划任务（如 Windows 任务计划程序、macOS/Linux 的 cron），每天自动运行一次即可完成日常提醒。

--- a/goal_manager.py
+++ b/goal_manager.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Simple goal manager for daily, weekly, monthly, and yearly targets.
+
+This script maintains a JSON file alongside the program so progress is
+remembered between runs. Users can add goals and run a daily reminder that asks
+whether each goal has been completed for the current period.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List, Literal, Optional
+
+Frequency = Literal["daily", "weekly", "monthly", "yearly"]
+
+
+DATA_FILE = Path(__file__).with_suffix(".json")
+
+
+def load_data() -> Dict[str, List[Dict[str, object]]]:
+    if DATA_FILE.exists():
+        with DATA_FILE.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return {"goals": []}
+
+
+def save_data(data: Dict[str, List[Dict[str, object]]]) -> None:
+    with DATA_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+
+
+def period_key(date: dt.date, frequency: Frequency) -> str:
+    if frequency == "daily":
+        return date.strftime("%Y-%m-%d")
+    if frequency == "weekly":
+        year, week, _ = date.isocalendar()
+        return f"{year}-W{week:02d}"
+    if frequency == "monthly":
+        return date.strftime("%Y-%m")
+    if frequency == "yearly":
+        return date.strftime("%Y")
+    raise ValueError(f"Unsupported frequency: {frequency}")
+
+
+def frequencies() -> Iterable[Frequency]:
+    yield from ("daily", "weekly", "monthly", "yearly")
+
+
+@dataclass
+class Goal:
+    name: str
+    frequency: Frequency
+    history: Dict[str, Dict[str, object]] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "Goal":
+        return cls(
+            name=str(payload["name"]),
+            frequency=payload["frequency"],
+            history=payload.get("history", {}),
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "frequency": self.frequency,
+            "history": self.history,
+        }
+
+    def status_for(self, date: dt.date) -> Optional[bool]:
+        record = self.history.get(period_key(date, self.frequency))
+        return None if record is None else bool(record["done"])
+
+    def set_status(self, date: dt.date, done: bool) -> None:
+        self.history[period_key(date, self.frequency)] = {
+            "done": done,
+            "updated_at": dt.datetime.now().isoformat(timespec="seconds"),
+        }
+
+
+def find_goal(goals: Iterable[Goal], name: str, frequency: Frequency) -> Goal:
+    for goal in goals:
+        if goal.name == name and goal.frequency == frequency:
+            return goal
+    raise SystemExit(f"Goal '{name}' ({frequency}) not found.")
+
+
+def add_goal(data: Dict[str, List[Dict[str, object]]], name: str, frequency: Frequency) -> None:
+    goals = [Goal.from_dict(item) for item in data.get("goals", [])]
+    for goal in goals:
+        if goal.name == name and goal.frequency == frequency:
+            raise SystemExit("Goal already exists.")
+    goals.append(Goal(name=name, frequency=frequency))
+    data["goals"] = [goal.to_dict() for goal in goals]
+    save_data(data)
+    print(f"Added {frequency} goal: {name}")
+
+
+def list_goals(data: Dict[str, List[Dict[str, object]]]) -> None:
+    goals = [Goal.from_dict(item) for item in data.get("goals", [])]
+    if not goals:
+        print("No goals defined yet. Use the 'add' command to create one.")
+        return
+
+    today = dt.date.today()
+    print("Current goals and today's status:\n")
+    for freq in frequencies():
+        freq_goals = [goal for goal in goals if goal.frequency == freq]
+        if not freq_goals:
+            continue
+        print(f"[{freq.capitalize()} goals]")
+        for goal in freq_goals:
+            status = goal.status_for(today)
+            indicator = {
+                True: "✅ Done",
+                False: "❌ Not done",
+                None: "⏳ Pending",
+            }[status]
+            print(f"- {goal.name}: {indicator}")
+        print()
+
+
+def check_goal(
+    data: Dict[str, List[Dict[str, object]]],
+    name: str,
+    frequency: Frequency,
+    done: bool,
+    date: Optional[dt.date] = None,
+) -> None:
+    goals = [Goal.from_dict(item) for item in data.get("goals", [])]
+    goal = find_goal(goals, name=name, frequency=frequency)
+    goal.set_status(date or dt.date.today(), done)
+    data["goals"] = [item.to_dict() for item in goals]
+    save_data(data)
+    print(f"Marked '{goal.name}' ({goal.frequency}) as {'done' if done else 'not done'}.")
+
+
+def prompt_yes_no(prompt: str) -> Optional[bool]:
+    while True:
+        response = input(prompt).strip().lower()
+        if not response:
+            return None
+        if response in {"y", "yes"}:
+            return True
+        if response in {"n", "no"}:
+            return False
+        print("Please enter 'y' for yes, 'n' for no, or press Enter to skip.")
+
+
+def remind(data: Dict[str, List[Dict[str, object]]]) -> None:
+    goals = [Goal.from_dict(item) for item in data.get("goals", [])]
+    if not goals:
+        print("No goals to remind you about. Add one with the 'add' command first.")
+        return
+
+    today = dt.date.today()
+    print("Daily goal reminder. Press Enter to leave a goal unchanged.")
+    for goal in goals:
+        status = goal.status_for(today)
+        status_text = {
+            True: "already marked as done",
+            False: "currently marked as not done",
+            None: "not yet recorded",
+        }[status]
+        answer = prompt_yes_no(
+            f"Did you finish '{goal.name}' ({goal.frequency}, {status_text})? [y/n/Enter] "
+        )
+        if answer is None:
+            continue
+        goal.set_status(today, answer)
+
+    data["goals"] = [goal.to_dict() for goal in goals]
+    save_data(data)
+    print("Reminder complete. Great job staying on track!")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Personal goal manager")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="Add a new goal")
+    add_parser.add_argument("name", help="Name of the goal")
+    add_parser.add_argument(
+        "--frequency",
+        choices=list(frequencies()),
+        default="daily",
+        help="How often the goal repeats",
+    )
+
+    list_parser = subparsers.add_parser("list", help="Show goals and their status")
+    list_parser
+
+    check_parser = subparsers.add_parser("check", help="Manually mark a goal done/not done")
+    check_parser.add_argument("name", help="Name of the goal")
+    check_parser.add_argument(
+        "--frequency",
+        choices=list(frequencies()),
+        default="daily",
+        help="Frequency of the goal",
+    )
+    status_group = check_parser.add_mutually_exclusive_group(required=True)
+    status_group.add_argument("--done", action="store_true", help="Mark as done")
+    status_group.add_argument("--not-done", action="store_true", help="Mark as not done")
+
+    subparsers.add_parser("remind", help="Run the interactive daily reminder")
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    data = load_data()
+
+    if args.command == "add":
+        add_goal(data, name=args.name, frequency=args.frequency)
+    elif args.command == "list":
+        list_goals(data)
+    elif args.command == "check":
+        done = True if args.done else False
+        check_goal(data, name=args.name, frequency=args.frequency, done=done)
+    elif args.command == "remind":
+        remind(data)
+    else:
+        raise SystemExit(f"Unknown command {args.command}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python command-line goal manager that stores progress for daily, weekly, monthly, and yearly goals
- implement commands to add, list, manually check, and run an interactive daily reminder
- document usage instructions in the README

## Testing
- python goal_manager.py list

------
https://chatgpt.com/codex/tasks/task_e_68d1cfb56ca0832295a66a08d7375466