### PR TITLE
Add Flask web interface for goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,29 @@
    ```
 
 建议把提醒命令加入系统的计划任务（如 Windows 任务计划程序、macOS/Linux 的 cron），每天自动运行一次即可完成日常提醒。
+
+## 运行 Web 界面
+
+除了命令行工具，还可以启动一个基于 Flask 的简单网页来管理目标：
+
+1. 安装依赖（如果尚未安装）：
+
+   ```bash
+   pip install flask
+   ```
+
+2. 在项目根目录启动开发服务器：
+
+   ```bash
+   FLASK_APP=web_app.py flask run
+   ```
+
+   或者使用较新的写法：
+
+   ```bash
+   python -m flask --app web_app run --debug
+   ```
+
+3. 打开浏览器访问 `http://127.0.0.1:5000/`，即可通过网页查看、添加或勾选目标。
+
+部署到服务器时，可以将 `web_app:app` 作为 WSGI 入口，交给如 Gunicorn、uWSGI 等 WSGI 容器或任何支持 WSGI 的平台来运行。

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <title>目标管理器</title>
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        padding: 0;
+        background-color: #f6f7fb;
+        color: #1f2933;
+      }
+
+      .container {
+        max-width: 720px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 3rem;
+      }
+
+      h1 {
+        text-align: center;
+        margin-bottom: 1.5rem;
+      }
+
+      .messages {
+        background: #fff3cd;
+        border: 1px solid #ffeeba;
+        color: #8a6d3b;
+        padding: 0.75rem 1rem;
+        border-radius: 0.5rem;
+        margin-bottom: 1.5rem;
+        list-style: none;
+      }
+
+      .form-card,
+      .goal-card {
+        background: #ffffff;
+        border-radius: 0.75rem;
+        padding: 1.25rem 1.5rem;
+        box-shadow: 0 10px 25px rgba(15, 23, 42, 0.08);
+        margin-bottom: 1.5rem;
+      }
+
+      label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 0.5rem;
+      }
+
+      input[type="text"],
+      select {
+        width: 100%;
+        padding: 0.6rem 0.75rem;
+        border-radius: 0.5rem;
+        border: 1px solid #d1d9e6;
+        margin-bottom: 1rem;
+        font-size: 1rem;
+      }
+
+      button {
+        background: #2563eb;
+        color: #ffffff;
+        border: none;
+        padding: 0.6rem 1rem;
+        border-radius: 0.5rem;
+        font-size: 0.95rem;
+        cursor: pointer;
+      }
+
+      button:hover,
+      button:focus {
+        background: #1d4ed8;
+      }
+
+      ul.goal-list {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+
+      .goal-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.75rem 0;
+        border-bottom: 1px solid #eef2f7;
+      }
+
+      .goal-item:last-child {
+        border-bottom: none;
+      }
+
+      .goal-info {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+      }
+
+      .goal-name {
+        font-weight: 600;
+      }
+
+      .status-label {
+        font-size: 0.95rem;
+        color: #52606d;
+      }
+
+      .empty-placeholder {
+        text-align: center;
+        color: #52606d;
+        padding: 1rem 0;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="container">
+      <h1>目标管理器</h1>
+
+      {% with messages = get_flashed_messages() %}
+        {% if messages %}
+          <ul class="messages">
+            {% for message in messages %}
+              <li>{{ message }}</li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      {% endwith %}
+
+      <section class="form-card">
+        <h2>添加新目标</h2>
+        <form method="post" action="{{ url_for('add_goal_route') }}">
+          <label for="name">目标名称</label>
+          <input id="name" name="name" type="text" placeholder="例如：阅读 30 分钟" required />
+
+          <label for="frequency">频率</label>
+          <select id="frequency" name="frequency">
+            {% for freq in frequencies %}
+              <option value="{{ freq }}">{{ frequency_labels.get(freq, freq) }}</option>
+            {% endfor %}
+          </select>
+
+          <button type="submit">添加目标</button>
+        </form>
+      </section>
+
+      <section>
+        <h2>当前目标</h2>
+        {% if not has_goals %}
+          <p class="empty-placeholder">暂无目标，使用上方表单添加一个吧。</p>
+        {% else %}
+          {% for freq in frequencies %}
+            {% set goals = goals_by_frequency.get(freq) %}
+            {% if goals %}
+              <article class="goal-card">
+                <h3>{{ frequency_labels.get(freq, freq) }}</h3>
+                <ul class="goal-list">
+                  {% for goal in goals %}
+                    <li class="goal-item">
+                      <div class="goal-info">
+                        <span class="goal-name">{{ goal.name }}</span>
+                        <span class="status-label">{{ status_labels[goal.status] }}</span>
+                      </div>
+                      <form method="post" action="{{ url_for('update_status_route') }}">
+                        <input type="hidden" name="name" value="{{ goal.name }}" />
+                        <input type="hidden" name="frequency" value="{{ freq }}" />
+                        {% if goal.status is sameas true %}
+                          <input type="hidden" name="done" value="false" />
+                          <button type="submit">标记未完成</button>
+                        {% else %}
+                          <input type="hidden" name="done" value="true" />
+                          <button type="submit">标记完成</button>
+                        {% endif %}
+                      </form>
+                    </li>
+                  {% endfor %}
+                </ul>
+              </article>
+            {% endif %}
+          {% endfor %}
+        {% endif %}
+      </section>
+    </main>
+  </body>
+</html>

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,151 @@
+"""Web application interface for the goal manager."""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Dict, Iterable, List, Tuple, cast
+
+from flask import Flask, flash, redirect, render_template, request, url_for
+
+from goal_manager import Frequency, Goal, load_data, save_data, frequencies
+
+app = Flask(__name__)
+app.secret_key = "dev"  # Needed for flash messages.
+
+FREQUENCIES: Tuple[Frequency, ...] = tuple(frequencies())
+FREQUENCY_LABELS = {
+    "daily": "每日目标",
+    "weekly": "每周目标",
+    "monthly": "每月目标",
+    "yearly": "每年目标",
+}
+
+
+def _load_goal_models() -> List[Goal]:
+    data = load_data()
+    return [Goal.from_dict(item) for item in data.get("goals", [])]
+
+
+def _persist_goal_models(goals: Iterable[Goal]) -> None:
+    payload: Dict[str, List[Dict[str, object]]] = {
+        "goals": [goal.to_dict() for goal in goals]
+    }
+    save_data(payload)
+
+
+def get_goals() -> List[Goal]:
+    """Return all goals stored in the JSON file."""
+    return _load_goal_models()
+
+
+def add_goal(name: str, frequency: Frequency) -> Goal:
+    """Create a new goal and persist it."""
+    if frequency not in FREQUENCIES:
+        raise ValueError("频率不在允许范围内。")
+
+    goals = _load_goal_models()
+    for goal in goals:
+        if goal.name == name and goal.frequency == frequency:
+            raise ValueError("该目标已经存在。")
+
+    new_goal = Goal(name=name, frequency=frequency)
+    goals.append(new_goal)
+    _persist_goal_models(goals)
+    return new_goal
+
+
+def update_status(name: str, frequency: Frequency, done: bool) -> Goal:
+    """Update the status of an existing goal for the current period."""
+    if frequency not in FREQUENCIES:
+        raise ValueError("频率不在允许范围内。")
+
+    goals = _load_goal_models()
+    for goal in goals:
+        if goal.name == name and goal.frequency == frequency:
+            goal.set_status(dt.date.today(), done)
+            _persist_goal_models(goals)
+            return goal
+
+    raise ValueError("未找到对应的目标。")
+
+
+@app.get("/")
+def index() -> str:
+    today = dt.date.today()
+    grouped: Dict[Frequency, List[Dict[str, object]]] = {
+        freq: [] for freq in FREQUENCIES
+    }
+    for goal in get_goals():
+        grouped.setdefault(goal.frequency, []).append(
+            {
+                "name": goal.name,
+                "status": goal.status_for(today),
+            }
+        )
+
+    for items in grouped.values():
+        items.sort(key=lambda item: item["name"].lower())
+
+    has_goals = any(grouped[freq] for freq in FREQUENCIES)
+
+    status_labels = {
+        True: "✅ 已完成",
+        False: "❌ 未完成",
+        None: "⏳ 未记录",
+    }
+
+    return render_template(
+        "index.html",
+        goals_by_frequency=grouped,
+        frequencies=FREQUENCIES,
+        frequency_labels=FREQUENCY_LABELS,
+        status_labels=status_labels,
+        has_goals=has_goals,
+    )
+
+
+@app.post("/add")
+def add_goal_route():
+    name = request.form.get("name", "").strip()
+    frequency = request.form.get("frequency", "daily")
+
+    if not name:
+        flash("目标名称不能为空。")
+        return redirect(url_for("index"))
+
+    try:
+        goal = add_goal(name=name, frequency=cast(Frequency, frequency))
+    except ValueError as exc:
+        flash(str(exc))
+    else:
+        flash(f"已添加目标：{goal.name}（{FREQUENCY_LABELS.get(goal.frequency, goal.frequency)}）。")
+
+    return redirect(url_for("index"))
+
+
+@app.post("/update")
+def update_status_route():
+    name = request.form.get("name", "").strip()
+    frequency = request.form.get("frequency", "")
+    done_raw = request.form.get("done", "true").lower()
+    done = done_raw in {"1", "true", "yes", "on"}
+
+    if not name:
+        flash("缺少目标名称。")
+        return redirect(url_for("index"))
+
+    try:
+        goal = update_status(
+            name=name, frequency=cast(Frequency, frequency), done=done
+        )
+    except ValueError as exc:
+        flash(str(exc))
+    else:
+        state = "完成" if done else "未完成"
+        flash(f"已将「{goal.name}」标记为{state}。")
+
+    return redirect(url_for("index"))
+
+
+if __name__ == "__main__":
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- add a Flask-based web module that reuses the goal manager logic through service helpers and exposes web routes for listing, adding, and updating goals
- create an HTML template to render grouped goal lists with forms for adding goals and toggling completion
- document how to run the web interface locally or in deployment environments in the README

## Testing
- python -m compileall web_app.py templates/index.html

------
https://chatgpt.com/codex/tasks/task_e_68d1d630578c8322abb1907f5a47154a