### PR TITLE
Add PyInstaller build script and persistent data directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
-# ss
-ss
+# 目标管理器
+
+这是一个简单的命令行目标管理器，可以在电脑上运行，用于记录每日、每周、每月和每年的目标完成情况。程序会把数据保存在当前用户的数据目录（例如 Windows 的 `%APPDATA%\GoalManager` 或 Linux 的 `~/.local/share/goal_manager`）下的 `goal_manager.json`，因此多次运行都会保留历史。
+
+## 使用方法
+
+1. **添加目标**
+
+   ```bash
+   python goal_manager.py add "锻炼" --frequency daily
+   python goal_manager.py add "整理财务" --frequency monthly
+   ```
+
+2. **查看目标和今日状态**
+
+   ```bash
+   python goal_manager.py list
+   ```
+
+3. **每日提醒**：运行下面的命令，程序会询问每个目标今天（或当期）是否完成，按下 `y`/`n` 或直接回车跳过。
+
+   ```bash
+   python goal_manager.py remind
+   ```
+
+4. **手动修改状态**
+
+   ```bash
+   python goal_manager.py check "锻炼" --frequency daily --done
+   python goal_manager.py check "整理财务" --frequency monthly --not-done
+   ```
+
+建议把提醒命令加入系统的计划任务（如 Windows 任务计划程序、macOS/Linux 的 cron），每天自动运行一次即可完成日常提醒。
+
+## 数据存储位置
+
+程序默认把数据写入：
+
+- **Windows**：`%APPDATA%\GoalManager\goal_manager.json`（若 `%APPDATA%` 不存在，则会回退到 `%LOCALAPPDATA%`）。
+- **macOS / Linux**：`~/.local/share/goal_manager/goal_manager.json`，或遵循 `XDG_DATA_HOME` 环境变量指定的目录。
+
+如果想把数据放到其它位置，可在启动命令前设置环境变量 `GOAL_MANAGER_DATA` 指向自定义目录，例如：
+
+```bash
+GOAL_MANAGER_DATA=~/Documents/goal-data python goal_manager.py remind
+```
+
+## 打包为 Windows 可执行文件
+
+仓库提供了 `build_exe.py` 脚本，用于调用 [PyInstaller](https://pyinstaller.org/) 打包成独立的 `GoalManager.exe`。在 Windows 机器（或安装了 PyInstaller 的环境）上依次执行：
+
+1. 安装依赖：
+
+   ```powershell
+   pip install pyinstaller
+   ```
+
+2. 运行打包脚本：
+
+   ```powershell
+   python build_exe.py
+   ```
+
+   完成后，可在仓库根目录的 `dist/GoalManager.exe` 找到可执行文件，把它复制到任意位置即可运行。
+
+若需要重新打包，只需再次运行脚本，它会自动清理旧的构建产物。

--- a/build_exe.py
+++ b/build_exe.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Build a standalone Goal Manager executable using PyInstaller."""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from pathlib import Path
+
+try:
+    from PyInstaller import __main__ as pyinstaller_main
+except ModuleNotFoundError:  # pragma: no cover - handled at runtime
+    pyinstaller_main = None
+
+
+def main() -> None:
+    if pyinstaller_main is None:
+        print("PyInstaller is required. Install it with 'pip install pyinstaller'.")
+        sys.exit(1)
+
+    project_root = Path(__file__).resolve().parent
+    dist_dir = project_root / "dist"
+    build_dir = project_root / "build"
+
+    # Clean previous build artifacts to avoid confusing results.
+    if build_dir.exists():
+        shutil.rmtree(build_dir)
+    dist_dir.mkdir(exist_ok=True)
+    exe_name = "GoalManager.exe" if sys.platform.startswith("win") else "GoalManager"
+    existing_binary = dist_dir / exe_name
+    if existing_binary.exists():
+        existing_binary.unlink()
+
+    print("Building Goal Manager executable with PyInstaller…")
+    pyinstaller_main.run(
+        [
+            "--name=GoalManager",
+            "--onefile",
+            "--console",
+            "--distpath",
+            str(dist_dir),
+            "--workpath",
+            str(build_dir),
+            str(project_root / "goal_manager.py"),
+        ]
+    )
+
+    output_path = dist_dir / exe_name
+    if output_path.exists():
+        print(f"Executable created at: {output_path}")
+    else:
+        print(
+            "PyInstaller finished but the expected executable was not found. "
+            "Check the PyInstaller output above for details."
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/goal_manager.py
+++ b/goal_manager.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Simple goal manager for daily, weekly, monthly, and yearly targets.
+
+The script stores progress in a JSON file under the user's application-data
+directory so that history is preserved between runs. Users can add goals and
+run a daily reminder that asks whether each goal has been completed for the
+current period.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+import sys
+from typing import Dict, Iterable, List, Literal, Optional
+
+Frequency = Literal["daily", "weekly", "monthly", "yearly"]
+
+
+APP_NAME = "GoalManager"
+DATA_ENV_VAR = "GOAL_MANAGER_DATA"
+
+
+def _resolve_data_dir() -> Path:
+    override = os.getenv(DATA_ENV_VAR)
+    if override:
+        return Path(override).expanduser().resolve()
+
+    if sys.platform.startswith("win"):
+        base = os.getenv("APPDATA") or os.getenv("LOCALAPPDATA")
+        if base:
+            base_path = Path(base)
+        else:
+            base_path = Path.home() / "AppData" / "Local"
+        return base_path / APP_NAME
+
+    xdg_home = os.getenv("XDG_DATA_HOME")
+    if xdg_home:
+        base_path = Path(xdg_home)
+    else:
+        base_path = Path.home() / ".local" / "share"
+    return base_path / APP_NAME.lower()
+
+
+DATA_DIR = _resolve_data_dir()
+DATA_FILE = DATA_DIR / "goal_manager.json"
+
+
+def load_data() -> Dict[str, List[Dict[str, object]]]:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    if DATA_FILE.exists():
+        with DATA_FILE.open("r", encoding="utf-8") as fh:
+            return json.load(fh)
+    return {"goals": []}
+
+
+def save_data(data: Dict[str, List[Dict[str, object]]]) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with DATA_FILE.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, ensure_ascii=False, indent=2)
+
+
+def period_key(date: dt.date, frequency: Frequency) -> str:
+    if frequency == "daily":
+        return date.strftime("%Y-%m-%d")
+    if frequency == "weekly":
+        year, week, _ = date.isocalendar()
+        return f"{year}-W{week:02d}"
+    if frequency == "monthly":
+        return date.strftime("%Y-%m")
+    if frequency == "yearly":
+        return date.strftime("%Y")
+    raise ValueError(f"Unsupported frequency: {frequency}")
+
+
+def frequencies() -> Iterable[Frequency]:
+    yield from ("daily", "weekly", "monthly", "yearly")
+
+
+@dataclass
+class Goal:
+    name: str
+    frequency: Frequency
+    history: Dict[str, Dict[str, object]] = field(default_factory=dict)
+
+    @classmethod
+    def from_dict(cls, payload: Dict[str, object]) -> "Goal":
+        return cls(
+            name=str(payload["name"]),
+            frequency=payload["frequency"],
+            history=payload.get("history", {}),
+        )
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "name": self.name,
+            "frequency": self.frequency,
+            "history": self.history,
+        }
+
+    def status_for(self, date: dt.date) -> Optional[bool]:
+        record = self.history.get(period_key(date, self.frequency))
+        return None if record is None else bool(record["done"])
+
+    def set_status(self, date: dt.date, done: bool) -> None:
+        self.history[period_key(date, self.frequency)] = {
+            "done": done,
+            "updated_at": dt.datetime.now().isoformat(timespec="seconds"),
+        }
+
+
+def find_goal(goals: Iterable[Goal], name: str, frequency: Frequency) -> Goal:
+    for goal in goals:
+        if goal.name == name and goal.frequency == frequency:
+            return goal
+    raise SystemExit(f"Goal '{name}' ({frequency}) not found.")
+
+
+def add_goal(data: Dict[str, List[Dict[str, object]]], name: str, frequency: Frequency) -> None:
+    goals = [Goal.from_dict(item) for item in data.get("goals", [])]
+    for goal in goals:
+        if goal.name == name and goal.frequency == frequency:
+            raise SystemExit("Goal already exists.")
+    goals.append(Goal(name=name, frequency=frequency))
+    data["goals"] = [goal.to_dict() for goal in goals]
+    save_data(data)
+    print(f"Added {frequency} goal: {name}")
+
+
+def list_goals(data: Dict[str, List[Dict[str, object]]]) -> None:
+    goals = [Goal.from_dict(item) for item in data.get("goals", [])]
+    if not goals:
+        print("No goals defined yet. Use the 'add' command to create one.")
+        return
+
+    today = dt.date.today()
+    print("Current goals and today's status:\n")
+    for freq in frequencies():
+        freq_goals = [goal for goal in goals if goal.frequency == freq]
+        if not freq_goals:
+            continue
+        print(f"[{freq.capitalize()} goals]")
+        for goal in freq_goals:
+            status = goal.status_for(today)
+            indicator = {
+                True: "✅ Done",
+                False: "❌ Not done",
+                None: "⏳ Pending",
+            }[status]
+            print(f"- {goal.name}: {indicator}")
+        print()
+
+
+def check_goal(
+    data: Dict[str, List[Dict[str, object]]],
+    name: str,
+    frequency: Frequency,
+    done: bool,
+    date: Optional[dt.date] = None,
+) -> None:
+    goals = [Goal.from_dict(item) for item in data.get("goals", [])]
+    goal = find_goal(goals, name=name, frequency=frequency)
+    goal.set_status(date or dt.date.today(), done)
+    data["goals"] = [item.to_dict() for item in goals]
+    save_data(data)
+    print(f"Marked '{goal.name}' ({goal.frequency}) as {'done' if done else 'not done'}.")
+
+
+def prompt_yes_no(prompt: str) -> Optional[bool]:
+    while True:
+        response = input(prompt).strip().lower()
+        if not response:
+            return None
+        if response in {"y", "yes"}:
+            return True
+        if response in {"n", "no"}:
+            return False
+        print("Please enter 'y' for yes, 'n' for no, or press Enter to skip.")
+
+
+def remind(data: Dict[str, List[Dict[str, object]]]) -> None:
+    goals = [Goal.from_dict(item) for item in data.get("goals", [])]
+    if not goals:
+        print("No goals to remind you about. Add one with the 'add' command first.")
+        return
+
+    today = dt.date.today()
+    print("Daily goal reminder. Press Enter to leave a goal unchanged.")
+    for goal in goals:
+        status = goal.status_for(today)
+        status_text = {
+            True: "already marked as done",
+            False: "currently marked as not done",
+            None: "not yet recorded",
+        }[status]
+        answer = prompt_yes_no(
+            f"Did you finish '{goal.name}' ({goal.frequency}, {status_text})? [y/n/Enter] "
+        )
+        if answer is None:
+            continue
+        goal.set_status(today, answer)
+
+    data["goals"] = [goal.to_dict() for goal in goals]
+    save_data(data)
+    print("Reminder complete. Great job staying on track!")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Personal goal manager")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    add_parser = subparsers.add_parser("add", help="Add a new goal")
+    add_parser.add_argument("name", help="Name of the goal")
+    add_parser.add_argument(
+        "--frequency",
+        choices=list(frequencies()),
+        default="daily",
+        help="How often the goal repeats",
+    )
+
+    list_parser = subparsers.add_parser("list", help="Show goals and their status")
+    list_parser
+
+    check_parser = subparsers.add_parser("check", help="Manually mark a goal done/not done")
+    check_parser.add_argument("name", help="Name of the goal")
+    check_parser.add_argument(
+        "--frequency",
+        choices=list(frequencies()),
+        default="daily",
+        help="Frequency of the goal",
+    )
+    status_group = check_parser.add_mutually_exclusive_group(required=True)
+    status_group.add_argument("--done", action="store_true", help="Mark as done")
+    status_group.add_argument("--not-done", action="store_true", help="Mark as not done")
+
+    subparsers.add_parser("remind", help="Run the interactive daily reminder")
+
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    data = load_data()
+
+    if args.command == "add":
+        add_goal(data, name=args.name, frequency=args.frequency)
+    elif args.command == "list":
+        list_goals(data)
+    elif args.command == "check":
+        done = True if args.done else False
+        check_goal(data, name=args.name, frequency=args.frequency, done=done)
+    elif args.command == "remind":
+        remind(data)
+    else:
+        raise SystemExit(f"Unknown command {args.command}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- persist goal data inside a user-specific application directory so it works when packaged
- add a build_exe.py helper that drives PyInstaller to generate a GoalManager.exe binary
- document the new storage location, environment override, and Windows packaging workflow in the README

## Testing
- python goal_manager.py list

------
https://chatgpt.com/codex/tasks/task_e_68d1cfb56ca0832295a66a08d7375466